### PR TITLE
Update package.json to increaase peerDependency for react v19

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "react": "^16 || ^17 || ^18",
-    "react-dom": "^16 || ^17 || ^18"
+    "react": "^16 || ^17 || ^18 || ^19",
+    "react-dom": "^16 || ^17 || ^18 || ^19"
   },
   "devDependencies": {
     "@size-limit/preset-small-lib": "^8.1.0",


### PR DESCRIPTION
Can you please update the library to accept react v19 as peerDependency. I am using this cool feature in new app and it drops deployments on vercel as I now upgraded to v19 react